### PR TITLE
Improve repo discoverability: badges, correct URLs, coverage docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Thank you for your interest in contributing to AgentDoctor! This guide will help
 
 ```bash
 # Clone the repository
-git clone https://github.com/mldeep-systems/agentdoctor.git
+git clone https://github.com/anmolp1/agentdoctor-oss.git
 cd agentdoctor
 
 # Install dependencies
@@ -240,7 +240,7 @@ pnpm test -- tests/unit/detectors/context-erosion.test.ts
 ### Coverage Requirements
 
 - Lines: 85%
-- Branches: 80%
+- Branches: 75%
 - Functions: 85%
 - Statements: 85%
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # AgentDoctor
 
+[![CI](https://github.com/anmolp1/agentdoctor-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/anmolp1/agentdoctor-oss/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/agentdoctor.svg)](https://www.npmjs.com/package/agentdoctor)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
+
 **Diagnose your AI agents before they silently fail.**
 
 AgentDoctor is a TypeScript library and CLI tool for AI agent health diagnostics. It analyzes agent log files to detect pathologies -- recurring failure patterns that degrade agent performance over time -- and computes a composite health score. It runs entirely locally, requires zero external services, and produces fully deterministic results.

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mldeep-systems/agentdoctor"
+    "url": "https://github.com/anmolp1/agentdoctor-oss"
   },
-  "homepage": "https://github.com/mldeep-systems/agentdoctor",
-  "bugs": "https://github.com/mldeep-systems/agentdoctor/issues",
+  "homepage": "https://github.com/anmolp1/agentdoctor-oss",
+  "bugs": "https://github.com/anmolp1/agentdoctor-oss/issues",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary
- Add CI, npm, license, Node.js, and PRs Welcome badges to README header
- Fix repository URLs in `package.json` pointing to old `mldeep-systems/agentdoctor` (now `anmolp1/agentdoctor-oss`)
- Fix clone URL in `CONTRIBUTING.md` to point to the OSS repo
- Fix documented branch coverage threshold (80% → 75%) in CONTRIBUTING.md to match `vitest.config.ts`

## Test plan
- [x] `pnpm run lint` — passes
- [x] `pnpm run format:check` — passes
- [x] `pnpm run typecheck` — passes

https://claude.ai/code/session_01U8sKQazwj8BPSLnihqt4sJ