### PR TITLE
Fix CHANGELOG URLs for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,5 +34,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with ESM and CJS dual-package exports
 - stdin support for piping logs directly
 
-[Unreleased]: https://github.com/mldeep-systems/agentdoctor/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/mldeep-systems/agentdoctor/releases/tag/v0.1.0
+[Unreleased]: https://github.com/anmolp1/agentdoctor-oss/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/anmolp1/agentdoctor-oss/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Fix CHANGELOG comparison and release URLs from `mldeep-systems/agentdoctor` to `anmolp1/agentdoctor-oss`
- Required before tagging `v0.1.0` so the GitHub Release body links work correctly

## Test plan
- [x] No code changes — documentation only

https://claude.ai/code/session_01U8sKQazwj8BPSLnihqt4sJ